### PR TITLE
Add review controller and routes

### DIFF
--- a/backend/controllers/reviewController.js
+++ b/backend/controllers/reviewController.js
@@ -1,0 +1,51 @@
+const Review = require('../models/Review');
+
+exports.createReview = async (req, res) => {
+  try {
+    const review = await Review.create({
+      movieId: req.body.movieId,
+      userId: req.user.id,
+      text: req.body.text,
+      rating: req.body.rating,
+    });
+    res.json(review);
+  } catch (err) {
+    res.status(400).json({ msg: 'Unable to create review' });
+  }
+};
+
+exports.getReviewsByMovie = async (req, res) => {
+  try {
+    const reviews = await Review.find({ movieId: req.params.movieId });
+    res.json(reviews);
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+};
+
+exports.updateReview = async (req, res) => {
+  try {
+    let review = await Review.findById(req.params.id);
+    if (!review) return res.status(404).send('Review not found');
+    if (review.userId.toString() !== req.user.id) return res.status(401).send('Unauthorized');
+
+    review.text = req.body.text ?? review.text;
+    review.rating = req.body.rating ?? review.rating;
+    await review.save();
+    res.json(review);
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+};
+
+exports.deleteReview = async (req, res) => {
+  try {
+    const review = await Review.findById(req.params.id);
+    if (!review) return res.status(404).send('Review not found');
+    if (review.userId.toString() !== req.user.id) return res.status(401).send('Unauthorized');
+    await review.remove();
+    res.json({ msg: 'Review removed' });
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+};

--- a/backend/routes/reviews.js
+++ b/backend/routes/reviews.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth');
+const {
+  createReview,
+  getReviewsByMovie,
+  updateReview,
+  deleteReview,
+} = require('../controllers/reviewController');
+
+router.post('/', auth, createReview);
+router.get('/movie/:movieId', getReviewsByMovie);
+router.put('/:id', auth, updateReview);
+router.delete('/:id', auth, deleteReview);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,6 +12,7 @@ app.use(express.json());
 
 app.use('/api/auth', require('./routes/auth'));
 app.use('/api/movies', require('./routes/movies'));
+app.use('/api/reviews', require('./routes/reviews'));
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -33,3 +33,30 @@ curl -X POST http://localhost:5000/api/movies/favorites \
 ```bash
 curl -H "Authorization: Bearer <TOKEN>" http://localhost:5000/api/movies/favorites
 ```
+
+## Add Review
+```bash
+curl -X POST http://localhost:5000/api/reviews \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"movieId":550,"text":"Great movie!","rating":5}'
+```
+
+## Get Reviews for Movie
+```bash
+curl http://localhost:5000/api/reviews/movie/550
+```
+
+## Update Review
+```bash
+curl -X PUT http://localhost:5000/api/reviews/<REVIEW_ID> \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Updated text","rating":4}'
+```
+
+## Delete Review
+```bash
+curl -X DELETE http://localhost:5000/api/reviews/<REVIEW_ID> \
+  -H "Authorization: Bearer <TOKEN>"
+```


### PR DESCRIPTION
## Summary
- add CRUD controller for reviews
- wire up review routes and mount in server
- document curl examples for review endpoints

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddd2742e88333b9e61025214f332f