### PR TITLE
Add watchlist and favorites routes

### DIFF
--- a/backend/controllers/movieController.js
+++ b/backend/controllers/movieController.js
@@ -38,3 +38,21 @@ exports.addWatchlist = async (req, res) => {
   await user.save();
   res.json(user.watchlist);
 };
+
+exports.removeFavorite = async (req, res) => {
+  const user = await User.findById(req.user.id);
+  user.favorites = user.favorites.filter(
+    (id) => id.toString() !== req.params.movieId
+  );
+  await user.save();
+  res.json(user.favorites);
+};
+
+exports.removeWatchlist = async (req, res) => {
+  const user = await User.findById(req.user.id);
+  user.watchlist = user.watchlist.filter(
+    (id) => id.toString() !== req.params.movieId
+  );
+  await user.save();
+  res.json(user.watchlist);
+};

--- a/backend/routes/movies.js
+++ b/backend/routes/movies.js
@@ -7,12 +7,16 @@ const {
   addFavorite,
   getWatchlist,
   addWatchlist,
+  removeFavorite,
+  removeWatchlist,
 } = require('../controllers/movieController');
 
 router.get('/search', search);
 router.get('/favorites', auth, getFavorites);
 router.post('/favorites', auth, addFavorite);
+router.delete('/favorites/:movieId', auth, removeFavorite);
 router.get('/watchlist', auth, getWatchlist);
 router.post('/watchlist', auth, addWatchlist);
+router.delete('/watchlist/:movieId', auth, removeWatchlist);
 
 module.exports = router;

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -34,6 +34,31 @@ curl -X POST http://localhost:5000/api/movies/favorites \
 curl -H "Authorization: Bearer <TOKEN>" http://localhost:5000/api/movies/favorites
 ```
 
+## Remove Favorite
+```bash
+curl -X DELETE http://localhost:5000/api/movies/favorites/<MOVIE_ID> \
+  -H "Authorization: Bearer <TOKEN>"
+```
+
+## Add to Watchlist
+```bash
+curl -X POST http://localhost:5000/api/movies/watchlist \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"movieId":550}'
+```
+
+## View Watchlist
+```bash
+curl -H "Authorization: Bearer <TOKEN>" http://localhost:5000/api/movies/watchlist
+```
+
+## Remove Watchlist Item
+```bash
+curl -X DELETE http://localhost:5000/api/movies/watchlist/<MOVIE_ID> \
+  -H "Authorization: Bearer <TOKEN>"
+```
+
 ## Add Review
 ```bash
 curl -X POST http://localhost:5000/api/reviews \

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,8 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Home from './pages/Home';
+import Watchlist from './pages/Watchlist';
+import Favorites from './pages/Favorites';
 
 function App() {
   return (
@@ -11,6 +13,8 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/watchlist" element={<Watchlist />} />
+        <Route path="/favorites" element={<Favorites />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/pages/Favorites.js
+++ b/frontend/src/pages/Favorites.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const Favorites = () => {
+  const [movies, setMovies] = useState([]);
+
+  const fetchFavorites = async () => {
+    try {
+      const { data: ids } = await axios.get(
+        `${process.env.REACT_APP_API_URL}/api/movies/favorites`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('token')}`,
+          },
+        }
+      );
+      const moviePromises = ids.map((id) =>
+        axios.get(
+          `https://api.themoviedb.org/3/movie/${id}?api_key=${process.env.REACT_APP_TMDB_KEY}`
+        )
+      );
+      const responses = await Promise.all(moviePromises);
+      setMovies(responses.map((res) => res.data));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchFavorites();
+  }, []);
+
+  const removeMovie = async (movieId) => {
+    try {
+      await axios.delete(
+        `${process.env.REACT_APP_API_URL}/api/movies/favorites/${movieId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('token')}`,
+          },
+        }
+      );
+      setMovies(movies.filter((m) => m.id !== movieId));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Your Favorites</h2>
+      <div className="movie-grid">
+        {movies.map((movie) => (
+          <div key={movie.id} className="movie-card" style={{ marginBottom: '1rem' }}>
+            {movie.poster_path && (
+              <img
+                src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
+                alt={movie.title}
+              />
+            )}
+            <h3>{movie.title}</h3>
+            <button onClick={() => removeMovie(movie.id)}>Remove</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Favorites;

--- a/frontend/src/pages/Watchlist.js
+++ b/frontend/src/pages/Watchlist.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const Watchlist = () => {
+  const [movies, setMovies] = useState([]);
+
+  const fetchWatchlist = async () => {
+    try {
+      const { data: ids } = await axios.get(
+        `${process.env.REACT_APP_API_URL}/api/movies/watchlist`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('token')}`,
+          },
+        }
+      );
+      const moviePromises = ids.map((id) =>
+        axios.get(
+          `https://api.themoviedb.org/3/movie/${id}?api_key=${process.env.REACT_APP_TMDB_KEY}`
+        )
+      );
+      const responses = await Promise.all(moviePromises);
+      setMovies(responses.map((res) => res.data));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchWatchlist();
+  }, []);
+
+  const removeMovie = async (movieId) => {
+    try {
+      await axios.delete(
+        `${process.env.REACT_APP_API_URL}/api/movies/watchlist/${movieId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('token')}`,
+          },
+        }
+      );
+      setMovies(movies.filter((m) => m.id !== movieId));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Your Watchlist</h2>
+      <div className="movie-grid">
+        {movies.map((movie) => (
+          <div key={movie.id} className="movie-card" style={{ marginBottom: '1rem' }}>
+            {movie.poster_path && (
+              <img
+                src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
+                alt={movie.title}
+              />
+            )}
+            <h3>{movie.title}</h3>
+            <button onClick={() => removeMovie(movie.id)}>Remove</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Watchlist;


### PR DESCRIPTION
## Summary
- add delete endpoints in movie controller and routes
- implement pages for watchlist and favorites
- wire up new React Router routes
- document new API calls for watchlist/favorites removal

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e075db964833396a313ca353f28d6