### PR TITLE
Add authentication context and protected routes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,8 @@ import Register from './pages/Register';
 import Home from './pages/Home';
 import Watchlist from './pages/Watchlist';
 import Favorites from './pages/Favorites';
+import SubmitReview from './pages/SubmitReview';
+import PrivateRoute from './components/PrivateRoute';
 
 function App() {
   return (
@@ -13,8 +15,30 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
-        <Route path="/watchlist" element={<Watchlist />} />
-        <Route path="/favorites" element={<Favorites />} />
+        <Route
+          path="/watchlist"
+          element={
+            <PrivateRoute>
+              <Watchlist />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/favorites"
+          element={
+            <PrivateRoute>
+              <Favorites />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/submit-review"
+          element={
+            <PrivateRoute>
+              <SubmitReview />
+            </PrivateRoute>
+          }
+        />
       </Routes>
     </Router>
   );

--- a/frontend/src/components/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute.js
@@ -1,0 +1,13 @@
+import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+const PrivateRoute = ({ children }) => {
+  const { token } = useContext(AuthContext);
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
+
+export default PrivateRoute;

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,0 +1,23 @@
+import React, { createContext, useState } from 'react';
+
+export const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+
+  const login = (jwt) => {
+    localStorage.setItem('token', jwt);
+    setToken(jwt);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/index.css';
+import { AuthProvider } from './context/AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <AuthProvider>
+    <App />
+  </AuthProvider>
+);

--- a/frontend/src/pages/Favorites.js
+++ b/frontend/src/pages/Favorites.js
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
+import { AuthContext } from '../context/AuthContext';
 
 const Favorites = () => {
   const [movies, setMovies] = useState([]);
+  const { token } = useContext(AuthContext);
 
   const fetchFavorites = async () => {
     try {
@@ -10,7 +12,7 @@ const Favorites = () => {
         `${process.env.REACT_APP_API_URL}/api/movies/favorites`,
         {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${token}`,
           },
         }
       );
@@ -36,7 +38,7 @@ const Favorites = () => {
         `${process.env.REACT_APP_API_URL}/api/movies/favorites/${movieId}`,
         {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${token}`,
           },
         }
       );

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -1,9 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import axios from 'axios';
+import { AuthContext } from '../context/AuthContext';
 
 const Home = () => {
   const [query, setQuery] = useState('');
   const [movies, setMovies] = useState([]);
+  const { token } = useContext(AuthContext);
 
   const searchMovies = async (e) => {
     e.preventDefault();
@@ -29,7 +31,7 @@ const Home = () => {
         { movieId },
         {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${token}`,
           },
         }
       );
@@ -45,7 +47,7 @@ const Home = () => {
         { movieId },
         {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${token}`,
           },
         }
       );

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
 
 const Login = () => {
   const [formData, setFormData] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
   const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
 
   const onChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -18,7 +20,7 @@ const Login = () => {
         `${process.env.REACT_APP_API_URL}/api/auth/login`,
         formData
       );
-      localStorage.setItem('token', res.data.token);
+      login(res.data.token);
       navigate('/');
     } catch (err) {
       setError(err.response?.data?.msg || 'Login failed');

--- a/frontend/src/pages/SubmitReview.js
+++ b/frontend/src/pages/SubmitReview.js
@@ -1,0 +1,76 @@
+import React, { useState, useContext } from 'react';
+import axios from 'axios';
+import { AuthContext } from '../context/AuthContext';
+
+const SubmitReview = () => {
+  const [formData, setFormData] = useState({ movieId: '', rating: '', text: '' });
+  const [message, setMessage] = useState('');
+  const { token } = useContext(AuthContext);
+
+  const onChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await axios.post(
+        `${process.env.REACT_APP_API_URL}/api/reviews`,
+        {
+          movieId: formData.movieId,
+          rating: Number(formData.rating),
+          text: formData.text,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      setMessage('Review submitted!');
+      setFormData({ movieId: '', rating: '', text: '' });
+    } catch (err) {
+      console.error(err);
+      setMessage('Submission failed');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Submit Review</h2>
+      {message && <p>{message}</p>}
+      <form onSubmit={onSubmit}>
+        <div>
+          <input
+            type="number"
+            name="movieId"
+            placeholder="Movie ID"
+            value={formData.movieId}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <div>
+          <input
+            type="number"
+            name="rating"
+            placeholder="Rating (1-10)"
+            value={formData.rating}
+            onChange={onChange}
+          />
+        </div>
+        <div>
+          <textarea
+            name="text"
+            placeholder="Your review"
+            value={formData.text}
+            onChange={onChange}
+          />
+        </div>
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  );
+};
+
+export default SubmitReview;

--- a/frontend/src/pages/Watchlist.js
+++ b/frontend/src/pages/Watchlist.js
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
+import { AuthContext } from '../context/AuthContext';
 
 const Watchlist = () => {
   const [movies, setMovies] = useState([]);
+  const { token } = useContext(AuthContext);
 
   const fetchWatchlist = async () => {
     try {
@@ -10,7 +12,7 @@ const Watchlist = () => {
         `${process.env.REACT_APP_API_URL}/api/movies/watchlist`,
         {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${token}`,
           },
         }
       );
@@ -36,7 +38,7 @@ const Watchlist = () => {
         `${process.env.REACT_APP_API_URL}/api/movies/watchlist/${movieId}`,
         {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${token}`,
           },
         }
       );


### PR DESCRIPTION
## Summary
- create `AuthContext` for storing JWT
- add `PrivateRoute` component for auth guarding
- wrap Watchlist, Favorites, and SubmitReview routes with auth guard
- wire context provider into the app and update pages to use token from context
- add simple SubmitReview page

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684e0d6592cc8333a362a626f6159432