### PR TITLE
Add CI workflow for Node projects

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,48 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test
+      - name: Deploy to Render
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          curl -X POST "$RENDER_DEPLOY_HOOK_URL"
+
+  frontend:
+    runs-on: ubuntu-latest
+    needs: backend
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test -- --watchAll=false
+      - run: npm run build
+      - name: Deploy to Vercel
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.VERCEL_TOKEN }}
+        uses: vercel/action@v2
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          org-id: ${{ secrets.VERCEL_ORG_ID }}
+          project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: frontend


### PR DESCRIPTION
## Summary
- add Node CI workflow that installs dependencies and runs tests for backend and frontend
- add optional deployment steps to Render and Vercel

## Testing
- `npm install` and `npm test` in `backend` *(failed: DownloadError for MongoMemoryServer)*
- `npm install` and `npm test -- --watchAll=false` in `frontend` *(failed: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684e133bd58c8333a1d03388f1868b44