### PR TITLE
Add search filters and movie recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,30 @@
-# Movie Recommendation App
+# Capstone
 
 ## Overview
-A fullstack application that allows users to search movies using the TMDB API, maintain watchlists and favorites, and review films.
+Capstone is a full-featured movie recommendation platform where users can discover, search, and save their favorite movies.
+
+## Core Features
+1. **User Authentication**
+   - User registration and login
+   - Secure password handling
+   - JWT token-based authentication
+2. **Movie Discovery**
+   - Search movies by title, genre, or year
+   - Filter by rating, release date, and popularity
+   - View detailed movie information
+   - Get personalized recommendations
+3. **User Features**
+   - Save favorite movies
+   - Create custom watchlists
+   - Rate and review movies
+   - User profile management
+
+## Technical Requirements
+* React frontend with modern UI components
+* Express.js backend with RESTful API
+* MongoDB database for user data
+* Integration with external movie API (e.g., TMDB)
+* Responsive design for mobile and desktop
 
 ## Tech Stack
 - **Frontend:** React, Axios, Vercel
@@ -67,6 +90,7 @@ frontend/      React application
 ## How to Deploy
 - **Frontend:** Deploy `frontend/` folder to Vercel.
 - **Backend:** Deploy `backend/` folder to Render.
+- Set up CI/CD pipeline
 
 ## Deployment URLs
 - **Frontend:** <https://movie-app.vercel.app>

--- a/backend/controllers/movieController.js
+++ b/backend/controllers/movieController.js
@@ -8,7 +8,31 @@ const tmdb = axios.create({
 
 exports.search = async (req, res) => {
   try {
-    const { data } = await tmdb.get('/search/movie', { params: { query: req.query.title } });
+    const { title, genre, year, rating, sort } = req.query;
+    const params = {};
+
+    let endpoint = '/search/movie';
+    if (title) {
+      params.query = title;
+    } else {
+      endpoint = '/discover/movie';
+    }
+
+    if (genre) params.with_genres = genre;
+    if (year) params.primary_release_year = year;
+    if (rating) params['vote_average.gte'] = rating;
+    if (sort) params.sort_by = sort;
+
+    const { data } = await tmdb.get(endpoint, { params });
+    res.json(data);
+  } catch (err) {
+    res.status(500).send('TMDB error');
+  }
+};
+
+exports.getRecommendations = async (req, res) => {
+  try {
+    const { data } = await tmdb.get('/movie/popular');
     res.json(data);
   } catch (err) {
     res.status(500).send('TMDB error');

--- a/backend/routes/movies.js
+++ b/backend/routes/movies.js
@@ -9,9 +9,11 @@ const {
   addWatchlist,
   removeFavorite,
   removeWatchlist,
+  getRecommendations,
 } = require('../controllers/movieController');
 
 router.get('/search', search);
+router.get('/recommendations', auth, getRecommendations);
 router.get('/favorites', auth, getFavorites);
 router.post('/favorites', auth, addFavorite);
 router.delete('/favorites/:movieId', auth, removeFavorite);

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -50,6 +50,34 @@ describe('Movie operations', () => {
     expect(res.body.results[0].title).toBe('Mock');
   });
 
+  test('searches movies with filters', async () => {
+    axiosInstance.get.mockResolvedValue({ data: { results: [{ id: 2, title: 'Filter' }] } });
+    const res = await request(app)
+      .get('/api/movies/search')
+      .query({ genre: '28', rating: 7, sort: 'popularity.desc' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.results[0].title).toBe('Filter');
+  });
+
+  test('returns movie recommendations', async () => {
+    axiosInstance.get.mockResolvedValue({ data: { results: [{ id: 3, title: 'Rec' }] } });
+    await request(app)
+      .post('/api/auth/register')
+      .send({ name: 'Rec', email: 'rec@example.com', password: 'pass' });
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'rec@example.com', password: 'pass' });
+    const token = login.body.token;
+
+    const res = await request(app)
+      .get('/api/movies/recommendations')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.results[0].title).toBe('Rec');
+  });
+
   test('handles watchlist operations', async () => {
     await request(app)
       .post('/api/auth/register')

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -5,7 +5,12 @@ import { AuthContext } from '../context/AuthContext';
 
 const Home = () => {
   const [query, setQuery] = useState('');
+  const [genre, setGenre] = useState('');
+  const [year, setYear] = useState('');
+  const [rating, setRating] = useState('');
+  const [sort, setSort] = useState('');
   const [movies, setMovies] = useState([]);
+  const [recommended, setRecommended] = useState([]);
   const { token } = useContext(AuthContext);
 
   useEffect(() => {
@@ -21,18 +26,39 @@ const Home = () => {
       }
     };
 
+    const fetchRec = async () => {
+      if (!token) return;
+      try {
+        const res = await axios.get(
+          `${process.env.REACT_APP_API_URL}/api/movies/recommendations`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        setRecommended(res.data.results || []);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
     fetchTrending();
-  }, []);
+    fetchRec();
+  }, [token]);
 
   const searchMovies = async (e) => {
     e.preventDefault();
-    if (!query.trim()) return;
+    if (!query.trim() && !genre && !year && !rating) return;
 
     try {
       const res = await axios.get(
         `${process.env.REACT_APP_API_URL}/api/movies/search`,
         {
-          params: { title: query, api_key: process.env.REACT_APP_TMDB_KEY },
+          params: {
+            title: query,
+            genre,
+            year,
+            rating,
+            sort,
+            api_key: process.env.REACT_APP_TMDB_KEY,
+          },
         }
       );
       setMovies(res.data.results || []);
@@ -83,6 +109,31 @@ const Home = () => {
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Enter movie title"
         />
+        <input
+          type="text"
+          value={genre}
+          onChange={(e) => setGenre(e.target.value)}
+          placeholder="Genre ID"
+        />
+        <input
+          type="number"
+          value={year}
+          onChange={(e) => setYear(e.target.value)}
+          placeholder="Year"
+        />
+        <input
+          type="number"
+          value={rating}
+          onChange={(e) => setRating(e.target.value)}
+          placeholder="Min Rating"
+          step="0.1"
+        />
+        <select value={sort} onChange={(e) => setSort(e.target.value)}>
+          <option value="">Sort</option>
+          <option value="popularity.desc">Popularity</option>
+          <option value="release_date.desc">Release Date</option>
+          <option value="vote_average.desc">Rating</option>
+        </select>
         <button type="submit">Search</button>
       </form>
 
@@ -104,6 +155,28 @@ const Home = () => {
           </div>
         ))}
       </div>
+      {recommended.length > 0 && (
+        <div>
+          <h3>Recommended For You</h3>
+          <div className="movie-grid">
+            {recommended.map((movie) => (
+              <div key={movie.id} className="movie-card" style={{ marginBottom: '1rem' }}>
+                <Link to={`/movie/${movie.id}`}>
+                  {movie.poster_path && (
+                    <img
+                      src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
+                      alt={movie.title}
+                    />
+                  )}
+                </Link>
+                <h3>{movie.title}</h3>
+                <button onClick={() => addWatchlist(movie.id)}>Add to Watchlist</button>
+                <button onClick={() => addFavorite(movie.id)}>Add to Favorite</button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- rename project to **Capstone** and document core features and deployment
- allow movie search filtering and expose `/recommendations` API
- update front-end home page for filters and recommendations
- expand API tests for new endpoints

## Testing
- `npm test --prefix backend` *(fails: process.exit called due to missing MongoDB binaries)*

------
https://chatgpt.com/codex/tasks/task_e_684e978755048333908553a1f0408a86