### PR TITLE
Add recommendations feature and home slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This is a full-stack movie recommendation application built with the MERN stack.
 - `POST /auth/login` – obtain JWT token
 - `GET /movies/search?q=query` – search movies via TMDB
 - `GET /movies/trending` – trending movies
+- `GET /movies/recommendations` – personalized recommendations (requires auth)
 - `GET /users/profile` – get current user profile (requires auth)
 - `POST /watchlist` – create a new watchlist (requires auth)
 - `PUT /watchlist/:id` – rename/update a watchlist (requires auth)

--- a/client/src/components/Slider.jsx
+++ b/client/src/components/Slider.jsx
@@ -1,0 +1,37 @@
+import { useRef } from 'react';
+
+const Slider = ({ title, children }) => {
+  const containerRef = useRef(null);
+  const scroll = (offset) => {
+    if (containerRef.current) {
+      containerRef.current.scrollBy({ left: offset, behavior: 'smooth' });
+    }
+  };
+  return (
+    <div className="mb-6">
+      {title && <h2 className="text-xl mb-2">{title}</h2>}
+      <div className="relative">
+        <button
+          className="absolute left-0 top-1/2 -translate-y-1/2 bg-gray-800 bg-opacity-50 px-2 z-10"
+          onClick={() => scroll(-300)}
+        >
+          &#8249;
+        </button>
+        <div
+          ref={containerRef}
+          className="overflow-x-auto flex gap-4 pb-2"
+        >
+          {children}
+        </div>
+        <button
+          className="absolute right-0 top-1/2 -translate-y-1/2 bg-gray-800 bg-opacity-50 px-2 z-10"
+          onClick={() => scroll(300)}
+        >
+          &#8250;
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Slider;

--- a/server/src/controllers/movieController.js
+++ b/server/src/controllers/movieController.js
@@ -1,4 +1,6 @@
 import fetch from 'node-fetch';
+import Watchlist from '../models/Watchlist.js';
+import Review from '../models/Review.js';
 
 const TMDB_BASE = 'https://api.themoviedb.org/3';
 
@@ -47,6 +49,42 @@ export const movieVideos = async (req, res) => {
     const response = await fetch(`${TMDB_BASE}/movie/${req.params.id}/videos?${query}`);
     const data = await response.json();
     res.json(data);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+export const recommendedMovies = async (req, res) => {
+  try {
+    // Fetch movies from user's watchlists and rated movies
+    const lists = await Watchlist.find({ user: req.user });
+    const watchlistIds = lists.flatMap(l => l.movies.map(m => m.tmdbId));
+    const reviews = await Review.find({ userId: req.user });
+    const ratedIds = reviews.map(r => r.movieId);
+    const uniqueIds = [...new Set([...watchlistIds, ...ratedIds])].slice(0, 5);
+
+    if (uniqueIds.length === 0) {
+      return res.json({ results: [] });
+    }
+
+    const query = new URLSearchParams({ api_key: process.env.TMDB_API_KEY });
+    const responses = await Promise.all(
+      uniqueIds.map(id =>
+        fetch(`${TMDB_BASE}/movie/${id}/recommendations?${query}`).then(r => r.json())
+      )
+    );
+
+    const all = responses.flatMap(r => r.results || []);
+    const seen = new Set();
+    const deduped = [];
+    for (const m of all) {
+      if (!seen.has(m.id)) {
+        seen.add(m.id);
+        deduped.push(m);
+      }
+    }
+
+    res.json({ results: deduped });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/server/src/routes/movies.js
+++ b/server/src/routes/movies.js
@@ -1,9 +1,11 @@
 import express from 'express';
-import { searchMovies, trendingMovies, movieDetails, movieVideos } from '../controllers/movieController.js';
+import { searchMovies, trendingMovies, movieDetails, movieVideos, recommendedMovies } from '../controllers/movieController.js';
+import { protect } from '../middleware/auth.js';
 
 const router = express.Router();
 router.get('/search', searchMovies);
 router.get('/trending', trendingMovies);
+router.get('/recommendations', protect, recommendedMovies);
 router.get('/:id/videos', movieVideos);
 router.get('/:id', movieDetails);
 export default router;


### PR DESCRIPTION
## Summary
- implement personalized recommendations API
- expose `/movies/recommendations` route
- show recommended movies slider on homepage when logged in
- create basic `Slider` component
- document the new endpoint in README

## Testing
- `npm --prefix server test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851651a0aa08333975ce0d3b9eebefe