### PR TITLE
Implement user following and shareable watchlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,16 @@ This is a full-stack movie recommendation application built with the MERN stack.
 - `POST /watchlist` - create a new watchlist (requires auth)  
 - `PUT /watchlist/:id` - rename/update a watchlist (requires auth)  
 - `DELETE /watchlist/:id` - delete a watchlist (requires auth)  
-- `POST /watchlist/:id/add` - add movie to watchlist (requires auth)  
-- `GET /watchlist` - list all watchlists with movies (requires auth)  
-- `DELETE /watchlist/:id/movies/:movieId` - remove movie from watchlist  
-- `POST /reviews/:movieId` - create a movie review (requires auth)  
-- `GET /reviews/:movieId` - list reviews for a movie  
-- `GET /movies/:id` - movie details  
+- `POST /watchlist/:id/add` - add movie to watchlist (requires auth)
+- `GET /watchlist` - list all watchlists with movies (requires auth)
+- `DELETE /watchlist/:id/movies/:movieId` - remove movie from watchlist
+- `GET /watchlist/shared/:id` - view a shared watchlist
+- `POST /reviews/:movieId` - create a movie review (requires auth)
+- `GET /reviews/:movieId` - list reviews for a movie
+- `POST /users/:id/follow` - follow another user (requires auth)
+- `DELETE /users/:id/follow` - unfollow a user (requires auth)
+- `GET /users/following/watchlists` - watchlists from followed users (requires auth)
+- `GET /movies/:id` - movie details
 
 ## Deployment
 - **Frontend** can be deployed to **Vercel**. Configure the `VITE_API_URL` environment variable on Vercel so the React app knows the Render backend URL.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ import Register from './pages/Register.jsx';
 import Profile from './pages/Profile.jsx';
 import Watchlist from './pages/Watchlist.jsx';
 import MovieDetail from './pages/MovieDetail.jsx';
+import SharedList from './pages/SharedList.jsx';
 import { Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext.jsx';
 
@@ -18,6 +19,7 @@ function App() {
         <Route path="/register" element={<Register />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/watchlist" element={<Watchlist />} />
+        <Route path="/list/:id" element={<SharedList />} />
         <Route path="/movie/:id" element={<MovieDetail />} />
       </Routes>
     </AuthProvider>

--- a/client/src/pages/SharedList.jsx
+++ b/client/src/pages/SharedList.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+import MovieCard from '../components/MovieCard.jsx';
+
+const SharedList = () => {
+  const { id } = useParams();
+  const [list, setList] = useState(null);
+
+  useEffect(() => {
+    axios.get(`/watchlist/shared/${id}`)
+      .then(res => setList(res.data))
+      .catch(() => setList(null));
+  }, [id]);
+
+  if (!list) return <p className="p-4">Loading...</p>;
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl mb-2">{list.name} - {list.user.name}</h2>
+      {list.description && <p className="mb-4 text-sm text-gray-300">{list.description}</p>}
+      {list.movies.length === 0 && <p>No movies.</p>}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {list.movies.map(m => (
+          <MovieCard key={m.tmdbId} movie={{ id: m.tmdbId, title: m.title, poster_path: m.posterPath }} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SharedList;

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -28,3 +28,44 @@ export const updateProfile = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+export const followUser = async (req, res) => {
+  try {
+    if (req.user === req.params.id) {
+      return res.status(400).json({ message: 'Cannot follow yourself' });
+    }
+    const user = await User.findById(req.user);
+    const target = await User.findById(req.params.id);
+    if (!target) return res.status(404).json({ message: 'User not found' });
+    if (!user.following.includes(target._id)) {
+      user.following.push(target._id);
+      await user.save();
+    }
+    res.json({ following: user.following });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+export const unfollowUser = async (req, res) => {
+  try {
+    const user = await User.findById(req.user);
+    user.following = user.following.filter(
+      u => u.toString() !== req.params.id
+    );
+    await user.save();
+    res.json({ following: user.following });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+export const getFollowedWatchlists = async (req, res) => {
+  try {
+    const user = await User.findById(req.user);
+    const lists = await Watchlist.find({ user: { $in: user.following } }).populate('user', 'name');
+    res.json(lists);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/server/src/controllers/watchlistController.js
+++ b/server/src/controllers/watchlistController.js
@@ -82,3 +82,14 @@ export const deleteMovie = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+// Public fetch of a watchlist by id for sharing
+export const getSharedWatchlist = async (req, res) => {
+  try {
+    const list = await Watchlist.findById(req.params.id).populate('user', 'name');
+    if (!list) return res.status(404).json({ message: 'Watchlist not found' });
+    res.json(list);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -4,6 +4,7 @@ const userSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
+  following: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
 }, { timestamps: true });
 
 export default mongoose.model('User', userSchema);

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -1,8 +1,17 @@
 import express from 'express';
-import { getProfile, updateProfile } from '../controllers/userController.js';
+import {
+  getProfile,
+  updateProfile,
+  followUser,
+  unfollowUser,
+  getFollowedWatchlists,
+} from '../controllers/userController.js';
 import { protect } from '../middleware/auth.js';
 
 const router = express.Router();
 router.get('/profile', protect, getProfile);
 router.put('/profile', protect, updateProfile);
+router.post('/:id/follow', protect, followUser);
+router.delete('/:id/follow', protect, unfollowUser);
+router.get('/following/watchlists', protect, getFollowedWatchlists);
 export default router;

--- a/server/src/routes/watchlist.js
+++ b/server/src/routes/watchlist.js
@@ -6,6 +6,7 @@ import {
   createWatchlist,
   updateWatchlist,
   deleteWatchlist,
+  getSharedWatchlist,
 } from '../controllers/watchlistController.js';
 import { protect } from '../middleware/auth.js';
 
@@ -16,4 +17,5 @@ router.put('/:id', protect, updateWatchlist);
 router.delete('/:id', protect, deleteWatchlist);
 router.post('/:id/add', protect, addMovie);
 router.delete('/:id/movies/:movieId', protect, deleteMovie);
+router.get('/shared/:id', getSharedWatchlist);
 export default router;


### PR DESCRIPTION
## Summary
- support following other users in the `User` model
- create follow/unfollow endpoints
- expose watchlists from followed users
- allow public fetch of shared watchlists
- add a page to show a shared watchlist
- route `/list/:id` for viewing shared lists
- document new API endpoints

## Testing
- `npm --prefix server test` *(fails: Missing script)*
- `npm --prefix client test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68516c2b48e08333b130c36f2d8ba33e