### PR TITLE
Fix movie details loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This is a full-stack movie recommendation application built with the MERN stack.
    ```
    The build output in `client/dist` includes the generated `manifest.webmanifest` and service worker.
 2. Deploy the **frontend** to **Vercel** and set the `VITE_API_URL` environment variable so the React app can reach the Render backend.
+   If this variable isn't provided or accidentally points to `localhost`, the client now falls back to the hosted backend URL.
 3. Deploy the **backend** to **Render** with environment variables `MONGO_URI`, `JWT_SECRET`, and `TMDB_API_KEY` configured.
    Vercel will automatically run the build script when deploying.
 4. Optional GitHub Actions workflows can be added to automate deployments.

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,4 +1,7 @@
 import axios from "axios";
+
+const envUrl = import.meta.env.VITE_API_URL;
+const defaultUrl = "https://threemtt-capstone.onrender.com";
 export const BASE_URL =
-  (import.meta.env.VITE_API_URL || "https://threemtt-capstone.onrender.com").replace(/\/+$/, '') + '/';
+  ((envUrl && !/localhost|127\.0\.0\.1/.test(envUrl) ? envUrl : defaultUrl).replace(/\/+$/, '')) + '/';
 export const api = axios.create({ baseURL: BASE_URL });


### PR DESCRIPTION
## Summary
- handle accidental localhost API URLs by falling back to the hosted backend
- document the fallback in README

## Testing
- `npm --prefix client run build`
- `npm --prefix server test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685689c1994083338c1f5f07b765072f