### PR TITLE
Add modal options when adding movies from cards

### DIFF
--- a/client/src/components/MovieCard.jsx
+++ b/client/src/components/MovieCard.jsx
@@ -1,18 +1,45 @@
-import { Link } from 'react-router-dom';
-import { useContext } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useContext, useState } from 'react';
 import { api } from '../api.js';
 import { motion } from 'framer-motion';
 import { AuthContext } from '../context/AuthContext.jsx';
+import Modal from './common/Modal.jsx';
 
 const MovieCard = ({ movie }) => {
   const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
 
-  const add = async (e) => {
-    e.preventDefault();
+  const addWatchlist = async () => {
     if (!user || !user.watchlists || user.watchlists.length === 0) return;
     const token = localStorage.getItem('token');
     const listId = user.watchlists[0]._id;
-    await api.post(`watchlist/${listId}/add`, { tmdbId: movie.id, title: movie.title, posterPath: movie.poster_path }, { headers: { Authorization: `Bearer ${token}` } });
+    await api.post(
+      `watchlist/${listId}/add`,
+      { tmdbId: movie.id, title: movie.title, posterPath: movie.poster_path },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    setOpen(false);
+  };
+
+  const addFavorite = async () => {
+    if (!user) return;
+    const token = localStorage.getItem('token');
+    await api.post(
+      'favorites/add',
+      { tmdbId: movie.id, title: movie.title, posterPath: movie.poster_path },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    setOpen(false);
+  };
+
+  const handleAdd = (e) => {
+    e.preventDefault();
+    if (!user) {
+      navigate('/register');
+    } else {
+      setOpen(true);
+    }
   };
 
   return (
@@ -20,15 +47,18 @@ const MovieCard = ({ movie }) => {
       <Link to={`/movie/${movie.id}`} className="bg-surface p-2 rounded relative block transition duration-300 hover:scale-105 hover:shadow-lg">
         <img src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`} alt={movie.title} className="mx-auto" />
         <h3 className="mt-2 text-center text-sm">{movie.title}</h3>
-        {user && (
-          <button
-            onClick={add}
-            className="absolute top-1 right-1 bg-brand hover:bg-brand/90 text-white text-xs px-1"
-          >
-            Add
-          </button>
-        )}
+        <button
+          onClick={handleAdd}
+          className="absolute top-1 right-1 bg-brand hover:bg-brand/90 text-white text-xs px-1"
+        >
+          Add
+        </button>
       </Link>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <p className="mb-2 text-center">Add to:</p>
+        <button onClick={addWatchlist} className="bg-brand hover:bg-brand/90 text-white px-3 py-1 mb-2 w-full text-sm">Watchlist</button>
+        <button onClick={addFavorite} className="bg-brand hover:bg-brand/90 text-white px-3 py-1 w-full text-sm">Favorites</button>
+      </Modal>
     </motion.div>
   );
 };

--- a/client/src/components/common/Modal.jsx
+++ b/client/src/components/common/Modal.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const Modal = ({ open, onClose, children }) => {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-surface p-4 rounded shadow-lg">
+        {children}
+        <button
+          onClick={onClose}
+          className="mt-2 text-sm bg-red-500 px-2 py-1 w-full"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
## Summary
- show add button to everyone and open a modal with options
- create a reusable `Modal` component

## Testing
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_6856aff886c88333a9471aa8b22e1c50