### PR TITLE
Fix movie detail loading and base URL

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,7 +1,5 @@
 import axios from "axios";
 
-const envUrl = import.meta.env.VITE_API_URL;
-const defaultUrl = "https://threemtt-capstone.onrender.com";
-export const BASE_URL =
-  ((envUrl && !/localhost|127\.0\.0\.1/.test(envUrl) ? envUrl : defaultUrl).replace(/\/+$/, '')) + '/';
+export const BASE_URL = (import.meta.env.VITE_API_URL || "https://threemtt-capstone.onrender.com")
+  .replace(/\/+$/, '') + '/';
 export const api = axios.create({ baseURL: BASE_URL });

--- a/client/src/pages/MovieDetails.jsx
+++ b/client/src/pages/MovieDetails.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import axios from 'axios';
+import { api } from '../api.js';
 
 const Container = styled.div`
   padding: 1rem;
@@ -29,9 +29,7 @@ const MovieDetails = () => {
     const fetchMovie = async () => {
       setLoading(true);
       try {
-        const res = await axios.get(
-          `https://api.themoviedb.org/3/movie/${id}?api_key=${import.meta.env.REACT_APP_TMDB_API_KEY}`
-        );
+        const res = await api.get(`movies/${id}`);
         setMovie(res.data);
       } catch (err) {
         console.error(err);
@@ -45,7 +43,11 @@ const MovieDetails = () => {
   }, [id]);
 
   if (loading) {
-    return <p className="p-4">Loading...</p>;
+    return (
+      <Container>
+        <p>Loading...</p>
+      </Container>
+    );
   }
 
   if (!movie) {


### PR DESCRIPTION
## Summary
- normalize API base url
- fetch movie details from API and show loading placeholder

## Testing
- `npm install` in `client`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857bba340a08333a98684d8adf4493f