### PR TITLE
Fix trailer placeholder

### DIFF
--- a/client/src/pages/MovieDetails.jsx
+++ b/client/src/pages/MovieDetails.jsx
@@ -67,7 +67,6 @@ const MovieDetails = () => {
     return <div className="p-4">Movie not found</div>;
   }
 
-  console.log('Movie loaded:', movie);
 
   return (
     <Container>
@@ -86,6 +85,7 @@ const MovieDetails = () => {
           alt={movie.title}
         />
       )}
+      {!video && <p>Trailer unavailable.</p>}
       <p>{movie.overview}</p>
       <p>Release Date: {movie.release_date}</p>
       <div className="flex gap-2 flex-wrap">


### PR DESCRIPTION
## Summary
- remove MovieDetails console debug log
- show "Trailer unavailable" notice when a trailer isn't found

## Testing
- `npm test` *(fails: could not find package.json)*
- `cd client && npm test` *(fails: missing script)*
- `cd server && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857d4d0b58c833389e36e65aab2c08d