### PR TITLE
Move recommendations to library

### DIFF
--- a/client/src/components/SmartRecommendations.jsx
+++ b/client/src/components/SmartRecommendations.jsx
@@ -1,0 +1,55 @@
+import { useContext, useEffect, useState } from 'react';
+import { api } from '../api.js';
+import MovieCard from './MovieCard.jsx';
+import Slider from './common/Slider.jsx';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+const SmartRecommendations = () => {
+  const { user } = useContext(AuthContext);
+  const [recommended, setRecommended] = useState([]);
+  const [advanced, setAdvanced] = useState([]);
+
+  useEffect(() => {
+    if (!user) {
+      setRecommended([]);
+      setAdvanced([]);
+      return;
+    }
+    const token = localStorage.getItem('token');
+    api.get('movies/recommendations', { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => setRecommended(res.data.results || []))
+      .catch(() => setRecommended([]));
+    api.get('movies/recommendations/advanced', { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => setAdvanced(res.data.results || []))
+      .catch(() => setAdvanced([]));
+  }, [user]);
+
+  if (!user) return null;
+
+  return (
+    <>
+      {recommended.length > 0 && (
+        <div className="mb-8">
+          <h3 className="text-lg mb-2">Recommended for You</h3>
+          <Slider>
+            {recommended.map(m => (
+              <MovieCard key={m.id} movie={m} />
+            ))}
+          </Slider>
+        </div>
+      )}
+      {advanced.length > 0 && (
+        <div className="mb-8">
+          <h3 className="text-lg mb-2">Top Picks</h3>
+          <Slider>
+            {advanced.map(m => (
+              <MovieCard key={m.id} movie={m} />
+            ))}
+          </Slider>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SmartRecommendations;

--- a/client/src/hooks/useMediaQuery.js
+++ b/client/src/hooks/useMediaQuery.js
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+const useMediaQuery = (query) => {
+  const getMatches = () =>
+    typeof window !== 'undefined' && window.matchMedia(query).matches;
+  const [matches, setMatches] = useState(getMatches());
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const listener = () => setMatches(media.matches);
+    media.addEventListener ? media.addEventListener('change', listener) : media.addListener(listener);
+    return () => {
+      media.removeEventListener ? media.removeEventListener('change', listener) : media.removeListener(listener);
+    };
+  }, [query]);
+
+  return matches;
+};
+
+export default useMediaQuery;

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -8,8 +8,6 @@ import { AuthContext } from '../context/AuthContext.jsx';
 
 const Home = () => {
   const [movies, setMovies] = useState([]);
-  const [recommended, setRecommended] = useState([]);
-  const [advanced, setAdvanced] = useState([]);
   const [page, setPage] = useState(1);
   const loader = useRef(null);
   const [hasMore, setHasMore] = useState(true);
@@ -51,26 +49,7 @@ const Home = () => {
   }, [page, searching]);
 
 
-  useEffect(() => {
-    if (!user) {
-      setRecommended([]);
-      setAdvanced([]);
-      return;
-    }
-    const token = localStorage.getItem('token');
-    api
-      .get('movies/recommendations', {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      .then(res => setRecommended(res.data.results))
-      .catch(() => setRecommended([]));
-    api
-      .get('movies/recommendations/advanced', {
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      .then(res => setAdvanced(res.data.results))
-      .catch(() => setAdvanced([]));
-  }, [user]);
+  // recommendations moved to Library/Watchlist views
 
   const handleSearch = async () => {
     try {
@@ -172,20 +151,6 @@ const Home = () => {
           </button>
         )}
       </div>
-      {user && recommended.length > 0 && (
-        <Slider title="Recommended for You">
-          {recommended.map(m => (
-            <MovieCard key={m.id} movie={m} />
-          ))}
-        </Slider>
-      )}
-      {user && advanced.length > 0 && (
-        <Slider title="Top Picks">
-          {advanced.map(m => (
-            <MovieCard key={m.id} movie={m} />
-          ))}
-        </Slider>
-      )}
       {trendingError && <p className="text-red-500 mb-2">{trendingError}</p>}
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
         {movies.map(m => <MovieCard key={m.id} movie={m} />)}

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -3,12 +3,14 @@ import { api } from '../api.js';
 import MovieCard from '../components/MovieCard.jsx';
 import Slider from '../components/common/Slider.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
+import SmartRecommendations from '../components/SmartRecommendations.jsx';
+import useMediaQuery from '../hooks/useMediaQuery.js';
 
 const Library = () => {
   const { user, setUser } = useContext(AuthContext);
   const [lists, setLists] = useState([]);
   const [favorites, setFavorites] = useState([]);
-  const [recommended, setRecommended] = useState([]);
+  const isDesktop = useMediaQuery('(min-width: 768px)');
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
 
@@ -21,9 +23,6 @@ const Library = () => {
     api.get('favorites', { headers: { Authorization: `Bearer ${token}` } })
       .then(res => setFavorites(res.data.movies || []))
       .catch(() => setFavorites([]));
-    api.get('movies/recommendations', { headers: { Authorization: `Bearer ${token}` } })
-      .then(res => setRecommended(res.data.results || []))
-      .catch(() => setRecommended([]));
   }, [user]);
 
   const create = async (e) => {
@@ -88,16 +87,7 @@ const Library = () => {
         </div>
       )}
 
-      {recommended.length > 0 && (
-        <div className="mb-8">
-          <h3 className="text-lg mb-2">For You</h3>
-          <Slider>
-            {recommended.map(m => (
-              <MovieCard key={m.id} movie={m} />
-            ))}
-          </Slider>
-        </div>
-      )}
+      {isDesktop && <SmartRecommendations />}
 
       <h3 className="text-lg mb-2">Watchlists</h3>
 
@@ -135,6 +125,8 @@ const Library = () => {
           </Slider>
         </div>
       ))}
+
+      {!isDesktop && <SmartRecommendations />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- create `useMediaQuery` hook for detecting viewport
- add `SmartRecommendations` component
- refactor `Library` to show smart picks based on screen size
- remove recommendation sections from `Home`

## Testing
- `npm --prefix client install`
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_6858366eb0f483338d701dfb985650c6