### PR TITLE
feat(ui): merged clean card, header, auth form

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,8 +1,7 @@
 import Header from './components/Header.jsx';
 import OfflineBanner from './components/OfflineBanner.jsx';
 import Home from './pages/Home.jsx';
-import Login from './pages/Login.jsx';
-import Register from './pages/Register.jsx';
+import AuthForm from './components/AuthForm.jsx';
 import Profile from './pages/Profile.jsx';
 import Library from './pages/Library.jsx';
 import MovieDetails from './pages/MovieDetails.jsx';
@@ -20,8 +19,8 @@ function App() {
       <div className="pt-16 pb-20">
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
+        <Route path="/login" element={<AuthForm mode="login" />} />
+        <Route path="/register" element={<AuthForm mode="register" />} />
         <Route element={<PrivateRoute />}>
           <Route path="/profile" element={<Profile />} />
           <Route path="/library" element={<Library />} />

--- a/client/src/components/AuthForm.jsx
+++ b/client/src/components/AuthForm.jsx
@@ -1,0 +1,110 @@
+import { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext.jsx';
+
+export default function AuthForm({ mode = 'login' }) {
+  const { login, register } = useContext(AuthContext);
+  const [isLogin, setIsLogin] = useState(mode === 'login');
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    password: "",
+  });
+  const [message, setMessage] = useState('');
+
+  const navigate = useNavigate();
+
+  const toggleForm = () => {
+    setIsLogin(!isLogin);
+    setMessage("");
+  };
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    let success = false;
+    if (isLogin) {
+      success = await login(formData.email, formData.password);
+      if (success) {
+        navigate('/profile');
+      } else {
+        setMessage('Invalid email or password');
+      }
+    } else {
+      success = await register(formData.name, formData.email, formData.password);
+      if (success) {
+        setMessage('Registration successful! Please log in.');
+        setIsLogin(true);
+      } else {
+        setMessage('Registration failed');
+      }
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md bg-surface p-6 rounded-3xl shadow-xl text-white">
+        <h2 className="text-2xl font-bold mb-4 text-center">
+          {isLogin ? "Login to CiFlix" : "Create Your Account"}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {!isLogin && (
+            <input
+              type="text"
+              name="name"
+              placeholder="Full Name"
+              value={formData.name}
+              onChange={handleChange}
+              className="w-full p-3 bg-surface placeholder-gray-400 rounded-3xl text-white"
+              required
+            />
+          )}
+          <input
+            type="email"
+            name="email"
+            placeholder="Email"
+            value={formData.email}
+            onChange={handleChange}
+            className="w-full p-3 rounded-3xl bg-surface placeholder-gray-400 text-white"
+            required
+          />
+          <input
+            type="password"
+            name="password"
+            placeholder="Password"
+            value={formData.password}
+            onChange={handleChange}
+            className="w-full p-3 rounded-3xl bg-surface placeholder-gray-400 text-white"
+            required
+          />
+
+          <button
+            type="submit"
+            className="w-full bg-red-600 hover:bg-red-700 p-3 rounded-3xl font-semibold transition cursor-pointer"
+          >
+            {isLogin ? "Login" : "Register"}
+          </button>
+        </form>
+
+        {message && (
+          <p className="mt-4 text-center text-sm text-red-400">{message}</p>
+        )}
+
+        <div className="mt-4 text-center">
+          <button
+            onClick={toggleForm}
+            className="text-sm text-blue-400 hover:underline cursor-pointer"
+          >
+            {isLogin
+              ? "Don't have an account? Register"
+              : "Already have an account? Login"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,41 +1,58 @@
-import { Link } from 'react-router-dom';
 import { useContext, useState } from 'react';
-import { HiMenu } from 'react-icons/hi';
+import { Link, useNavigate } from 'react-router-dom';
+import Logo from '/logo.svg';
 import { AuthContext } from '../context/AuthContext.jsx';
-import MobileDrawer from './MobileDrawer.jsx';
 
-const Header = () => {
+export default function Header() {
   const { user, logout } = useContext(AuthContext);
-  const [open, setOpen] = useState(false);
-
-  const menuItems = (
-    <>
-      <Link to="/">Home</Link>
-      {user ? (
-        <>
-          <Link to="/library">Library</Link>
-          <Link to="/profile">Profile</Link>
-          <button onClick={logout}>Logout</button>
-        </>
-      ) : (
-        <>
-          <Link to="/login">Login</Link>
-          <Link to="/register">Register</Link>
-        </>
-      )}
-    </>
-  );
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navigate = useNavigate();
 
   return (
-    <header className="fixed top-0 w-full z-50 bg-gradient-to-r from-purple-700 to-blue-500 p-4 flex justify-between items-center">
-      <Link to="/" className="font-bold">MyMovies</Link>
-      <div className="hidden md:flex space-x-4 items-center">{menuItems}</div>
-      <button className="md:hidden" onClick={() => setOpen(true)}>
-        <HiMenu size={24} />
-      </button>
-      {open && <MobileDrawer close={() => setOpen(false)} />}
+    <header className="bg-surface text-white p-5 w-full shadow-md fixed top-0 z-50">
+      <div className="container mx-auto flex items-center justify-between flex-wrap">
+        <div className="flex items-center cursor-pointer" onClick={() => navigate('/')}>
+          <img src={Logo} alt="CinemaFlix Logo" className="h-10 w-40 mr-3" />
+        </div>
+        <button className="block md:hidden text-white text-4xl" onClick={() => setMenuOpen(!menuOpen)}>
+          ☰
+        </button>
+        <div className={`w-full md:flex md:items-center md:w-auto ${menuOpen ? 'block' : 'hidden'}`}>
+          <div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-6 mt-4 md:mt-0 ml-auto">
+            <Link to="/" onClick={() => setMenuOpen(false)} className="hover:text-brand px-2 md:px-3">
+              Home
+            </Link>
+            {user ? (
+              <>
+                <Link to="/library" onClick={() => setMenuOpen(false)} className="hover:text-brand px-2 md:px-3">
+                  Library
+                </Link>
+                <Link to="/profile" onClick={() => setMenuOpen(false)} className="hover:text-brand px-2 md:px-3">
+                  Profile
+                </Link>
+                <button
+                  onClick={() => {
+                    logout();
+                    setMenuOpen(false);
+                  }}
+                  className="hover:text-brand px-2 md:px-3"
+                >
+                  Logout
+                </button>
+              </>
+            ) : (
+              <>
+                <Link to="/login" onClick={() => setMenuOpen(false)} className="hover:text-brand px-2 md:px-3">
+                  Login
+                </Link>
+                <Link to="/register" onClick={() => setMenuOpen(false)} className="hover:text-brand px-2 md:px-3">
+                  Register
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
     </header>
   );
-};
-
-export default Header;
+}

--- a/client/src/components/MovieCard.jsx
+++ b/client/src/components/MovieCard.jsx
@@ -1,16 +1,15 @@
 import { Link, useNavigate } from 'react-router-dom';
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import { api } from '../api.js';
 import { motion } from 'framer-motion';
 import { AuthContext } from '../context/AuthContext.jsx';
-import Modal from './common/Modal.jsx';
 
-const MovieCard = ({ movie }) => {
+const MovieCard = ({ movie, onAddFavorite, onAddWatchlist }) => {
   const { user } = useContext(AuthContext);
   const navigate = useNavigate();
-  const [open, setOpen] = useState(false);
 
   const addWatchlist = async () => {
+    if (onAddWatchlist) return onAddWatchlist(movie);
     if (!user || !user.watchlists || user.watchlists.length === 0) return;
     const token = localStorage.getItem('token');
     const listId = user.watchlists[0]._id;
@@ -19,10 +18,10 @@ const MovieCard = ({ movie }) => {
       { tmdbId: movie.id, title: movie.title, posterPath: movie.poster_path },
       { headers: { Authorization: `Bearer ${token}` } }
     );
-    setOpen(false);
   };
 
   const addFavorite = async () => {
+    if (onAddFavorite) return onAddFavorite(movie);
     if (!user) return;
     const token = localStorage.getItem('token');
     await api.post(
@@ -30,35 +29,23 @@ const MovieCard = ({ movie }) => {
       { tmdbId: movie.id, title: movie.title, posterPath: movie.poster_path },
       { headers: { Authorization: `Bearer ${token}` } }
     );
-    setOpen(false);
   };
 
-  const handleAdd = (e) => {
-    e.preventDefault();
-    if (!user) {
-      navigate('/register');
-    } else {
-      setOpen(true);
-    }
-  };
 
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5 }}>
-      <Link to={`/movie/${movie.id}`} className="bg-surface p-2 rounded relative block transition duration-300 hover:scale-105 hover:shadow-lg">
+      <Link to={`/movie/${movie.id}`} className="bg-surface p-2 rounded block transition duration-300 hover:scale-105 hover:shadow-lg">
         <img src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`} alt={movie.title} className="mx-auto" />
         <h3 className="mt-2 text-center text-sm">{movie.title}</h3>
-        <button
-          onClick={handleAdd}
-          className="absolute top-1 right-1 bg-brand hover:bg-brand/90 text-white text-xs px-1"
-        >
-          Add
-        </button>
       </Link>
-      <Modal open={open} onClose={() => setOpen(false)}>
-        <p className="mb-2 text-center">Add to:</p>
-        <button onClick={addWatchlist} className="bg-brand hover:bg-brand/90 text-white px-3 py-1 mb-2 w-full text-sm">Watchlist</button>
-        <button onClick={addFavorite} className="bg-brand hover:bg-brand/90 text-white px-3 py-1 w-full text-sm">Favorites</button>
-      </Modal>
+      <div className="flex justify-between mt-2">
+        <button onClick={addFavorite} className="bg-brand hover:bg-brand/90 text-white px-2 py-1 text-xs rounded">
+          ❤️ Favorite
+        </button>
+        <button onClick={addWatchlist} className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 text-xs rounded">
+          🎬 Watchlist
+        </button>
+      </div>
     </motion.div>
   );
 };

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -152,7 +152,7 @@ const Home = () => {
         )}
       </div>
       {trendingError && <p className="text-red-500 mb-2">{trendingError}</p>}
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
         {movies.map(m => <MovieCard key={m.id} movie={m} />)}
       </div>
       {hasMore && <div ref={loader} />}


### PR DESCRIPTION
## Summary
- replace header with new navigation and branding
- update movie card visuals and keep API logic
- add new AuthForm component
- use AuthForm in login/register routes
- tweak home page grid layout
- include new light mode logo asset
- remove unused png logo file

## Testing
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68585d917be48333b9f2e2ad8019e302