### PR TITLE
Fix search entry and button styles

### DIFF
--- a/client/src/components/MovieCard.jsx
+++ b/client/src/components/MovieCard.jsx
@@ -48,7 +48,7 @@ const MovieCard = ({ movie, onAddFavorite, onAddWatchlist }) => {
       </Link>
       <div className="p-2">
         <h3 className="text-center text-sm font-semibold truncate">{movie.title}</h3>
-        <div className="flex justify-between mt-2">
+        <div className="flex justify-center gap-2 mt-2">
           <button onClick={addFavorite} className="bg-brand hover:bg-brand/90 text-white px-2 py-1 text-xs rounded">
             ❤️ Favorite
           </button>

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -104,6 +104,12 @@ const Home = () => {
           type="text"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleSearch();
+            }
+          }}
           placeholder="Search movies..."
           className="bg-gray-100 text-black border border-gray-300 p-2 w-full rounded"
         />

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -22,7 +22,12 @@ const Login = () => {
     <form onSubmit={handleSubmit} className="p-4 max-w-sm mx-auto space-y-4">
       <input className="w-full p-2 text-black" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
       <input type="password" className="w-full p-2 text-black" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
-      <button className="w-full bg-blue-500 py-2" type="submit">Login</button>
+      <button
+        className="w-full bg-purple-600 text-white px-4 py-1 rounded"
+        type="submit"
+      >
+        Login
+      </button>
     </form>
   );
 };

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -25,7 +25,12 @@ const Register = () => {
       <input className="w-full p-2 text-black" value={name} onChange={e => setName(e.target.value)} placeholder="Name" />
       <input className="w-full p-2 text-black" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
       <input type="password" className="w-full p-2 text-black" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
-      <button className="w-full bg-blue-500 py-2" type="submit">Register</button>
+      <button
+        className="w-full bg-purple-600 text-white px-4 py-1 rounded"
+        type="submit"
+      >
+        Register
+      </button>
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- allow hitting Enter key to trigger search on home page
- space out buttons on movie cards
- make login and register buttons match search style

## Testing
- `npm test --if-present` (fails: no test specified)
- `cd server && npm test --if-present` (no output)
- `cd client && npm test --if-present` (no output)


------
https://chatgpt.com/codex/tasks/task_e_68587a8341b08333b0a8ce37c69a54e7