### PR TITLE
Improve search and user feedback

### DIFF
--- a/client/src/components/common/MovieCard.jsx
+++ b/client/src/components/common/MovieCard.jsx
@@ -7,14 +7,27 @@ const MovieCard = ({ movie, onRemove, children }) => {
       className="relative flex-shrink-0 w-36 sm:w-44"
       style={{ minWidth: '140px' }}
     >
-      {onRemove && (
-        <button
-          onClick={() => onRemove(id)}
-          className="absolute right-1 top-1 bg-black/50 rounded-full p-1 hover:bg-red-600"
-        >
-          &times;
-        </button>
-      )}
+        {onRemove && (
+          <button
+            onClick={() => onRemove(id)}
+            className="absolute right-1 top-1 bg-black/50 rounded-full p-1 hover:bg-red-700"
+            aria-label="Remove"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              className="w-3 h-3 text-red-500"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        )}
       <Link to={`/movie/${id}`}>
         <img
           src={`https://image.tmdb.org/t/p/w300${poster_path}`}

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -85,8 +85,8 @@ const Home = () => {
     }
   };
 
-  const handleSearch = () => {
-    if (searchQuery.trim()) fetchSearch(searchQuery, 1);
+  const handleSearch = async () => {
+    if (searchQuery.trim()) await fetchSearch(searchQuery, 1);
   };
 
   const goToPage = (newPage) => {
@@ -108,17 +108,17 @@ const Home = () => {
   return (
     <div className="p-4">
       <HeroVideo />
-      <div className="mb-4">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSearch();
+        }}
+        className="mb-4"
+      >
         <input
           type="text"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              handleSearch();
-            }
-          }}
           placeholder="Search movies..."
           className="bg-gray-100 text-black border border-gray-300 p-2 w-full rounded"
         />
@@ -162,7 +162,7 @@ const Home = () => {
           />
         </div>
         <button
-          onClick={handleSearch}
+          type="submit"
           className="mt-2 bg-purple-600 text-white px-4 py-1 rounded"
         >
           Search
@@ -178,7 +178,7 @@ const Home = () => {
             Clear
           </button>
         )}
-      </div>
+      </form>
       {trendingError && <p className="text-red-500 mb-2">{trendingError}</p>}
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
         {movies.map((m) => (

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -7,14 +7,17 @@ const Login = () => {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [status, setStatus] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setStatus('Logging in...');
     const success = await login(email, password);
     if (success) {
+      setStatus('Login successful');
       navigate('/profile');
     } else {
-      alert('Invalid email or password');
+      setStatus('Invalid email or password');
     }
   };
 
@@ -28,6 +31,7 @@ const Login = () => {
       >
         Login
       </button>
+      {status && <p className="text-center text-sm text-blue-300 mt-2">{status}</p>}
     </form>
   );
 };

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -8,15 +8,18 @@ const Register = () => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [status, setStatus] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setStatus('Registering...');
     const success = await register(name, email, password);
     if (success) {
+      setStatus('Registration successful');
       await login(email, password);
       navigate('/profile');
     } else {
-      alert('Registration failed');
+      setStatus('Registration failed');
     }
   };
 
@@ -31,6 +34,7 @@ const Register = () => {
       >
         Register
       </button>
+      {status && <p className="text-center text-sm text-blue-300 mt-2">{status}</p>}
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- wrap homepage search bar in a `<form>` and await searches
- add inline SVG remove icon to library cards
- show login/register status messages

## Testing
- `npm install` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68596fc9a1f48333a07957020cfd0c4e