### PR TITLE
Improve mobile layout

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -12,7 +12,11 @@ export default function Header() {
     <header className="bg-gradient-to-r from-brand-from to-brand-to text-white p-5 w-full shadow-md fixed top-0 z-50">
       <div className="container mx-auto flex items-center justify-between flex-wrap">
         <div className="flex items-center cursor-pointer" onClick={() => navigate('/')}>
-          <img src={Logo} alt="MyMovies Logo" className="h-10 w-40 mr-3" />
+          <img
+            src={Logo}
+            alt="MyMovies Logo"
+            className="h-10 w-40 mr-3 -ml-2 md:-ml-4"
+          />
         </div>
         <button className="block md:hidden text-white text-4xl" onClick={() => setMenuOpen(!menuOpen)}>
           ☰

--- a/client/src/components/MovieCard.jsx
+++ b/client/src/components/MovieCard.jsx
@@ -37,7 +37,7 @@ const MovieCard = ({ movie, onAddFavorite, onAddWatchlist }) => {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
-      className="bg-surface rounded overflow-hidden hover:shadow-lg"
+      className="bg-surface rounded overflow-hidden hover:shadow-lg w-36 sm:w-44 flex-shrink-0"
     >
       <div className="relative group">
         <Link to={`/movie/${movie.id}`}>

--- a/client/src/components/common/SearchBar.jsx
+++ b/client/src/components/common/SearchBar.jsx
@@ -7,7 +7,7 @@ const SearchBar = ({ value, onChange, onSubmit }) => {
         e.preventDefault();
         onSubmit && onSubmit();
       }}
-      className="w-full max-w-xl mx-auto"
+      className="w-full sm:max-w-xl mx-auto"
     >
       <div className="flex shadow-md">
         <input


### PR DESCRIPTION
## Summary
- tweak SearchBar width classes
- fix trending MovieCard width
- offset header logo slightly left

## Testing
- `npm --prefix client run build`
- `npm --prefix server install`

------
https://chatgpt.com/codex/tasks/task_e_685a7d28581483339d05f11eb20a5d72