### PR TITLE
Improve mobile UI and add poster

### DIFF
--- a/client/src/components/common/SearchBar.jsx
+++ b/client/src/components/common/SearchBar.jsx
@@ -9,17 +9,17 @@ const SearchBar = ({ value, onChange, onSubmit }) => {
       }}
       className="w-full sm:max-w-xl mx-auto"
     >
-      <div className="flex shadow-md">
+      <div className="flex shadow-md w-full">
         <input
           type="text"
           value={value}
           onChange={(e) => onChange && onChange(e.target.value)}
           placeholder="Search movies..."
-          className="flex-grow p-3 rounded-l text-black focus:outline-none"
+          className="flex-grow w-full p-3 bg-white rounded-l-md text-black focus:outline-none"
         />
         <button
           type="submit"
-          className="bg-gradient-to-r from-brand-from to-brand-to text-white px-4 rounded-r"
+          className="bg-gradient-to-r from-brand-from to-brand-to text-white px-4 rounded-r-md"
         >
           Search
         </button>

--- a/client/src/pages/Library.jsx
+++ b/client/src/pages/Library.jsx
@@ -100,20 +100,25 @@ const Library = () => {
 
         <h3 className="text-lg mb-2">Watchlists</h3>
 
-        <form onSubmit={create} className="mb-6 space-x-2">
+        <form onSubmit={create} className="mb-6 flex flex-col sm:flex-row gap-2">
           <input
-            className="p-1 text-black"
+            className="p-2 rounded-md border border-gray-300 text-black flex-1"
             value={name}
             onChange={e => setName(e.target.value)}
             placeholder="New list name"
           />
           <input
-            className="p-1 text-black"
+            className="p-2 rounded-md border border-gray-300 text-black flex-1"
             value={description}
             onChange={e => setDescription(e.target.value)}
             placeholder="Description"
           />
-          <button className="bg-blue-500 px-2" type="submit">Create</button>
+          <button
+            className="bg-blue-500 px-4 py-2 rounded-md text-white w-full sm:w-auto"
+            type="submit"
+          >
+            Create
+          </button>
         </form>
 
         {lists.length === 0 && <p>No watchlists yet.</p>}

--- a/client/src/pages/MovieDetails.jsx
+++ b/client/src/pages/MovieDetails.jsx
@@ -23,7 +23,9 @@ const Title = styled.h2`
 
 const Poster = styled.img`
   max-width: 300px;
-  border-radius: 4px;
+  width: 100%;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   align-self: center;
 `;
 
@@ -74,6 +76,12 @@ const MovieDetails = () => {
   return (
     <Container>
       <Title>{movie.title}</Title>
+      {movie.poster_path && (
+        <Poster
+          src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
+          alt={movie.title}
+        />
+      )}
       {video ? (
         <button
           onClick={() => setShowTrailer(true)}
@@ -82,14 +90,8 @@ const MovieDetails = () => {
           Watch Trailer
         </button>
       ) : (
-        movie.poster_path && (
-          <Poster
-            src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
-            alt={movie.title}
-          />
-        )
+        <p>Trailer unavailable.</p>
       )}
-      {!video && <p>Trailer unavailable.</p>}
       <p>{movie.overview}</p>
       <p>Release Date: {movie.release_date}</p>
       <div className="flex gap-2 flex-wrap">


### PR DESCRIPTION
## Summary
- adjust search bar to be full width on mobile
- improve styling of watchlist form inputs
- always display poster image on movie details page

## Testing
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_685aa71d08688333ab6bbae1386921f5